### PR TITLE
Improving clj-kondo hook

### DIFF
--- a/src/clj-kondo.exports/io.github.tonsky/clj-simple-router/hooks/routes.clj_kondo
+++ b/src/clj-kondo.exports/io.github.tonsky/clj-simple-router/hooks/routes.clj_kondo
@@ -12,6 +12,6 @@
          (for [[_ bindings body] (partition 3 body)]
            (api/list-node
              (list
-               (api/token-node 'fn)
-               bindings
+              (api/token-node 'fn)
+              (api/vector-node [bindings])
                body)))))}))


### PR DESCRIPTION
This commit attempts to improve the `clj-kondo` hook for the `routes` macro to better handle routes that receive a `req` map instead of a parsed `path-param` vector, as `clj-kondo` incorrectly raises warnings on those.

This is still a work in progress. Below are the linting results for the following bit of code:

```clojure
(def routes
  (router/routes
    ;; ...

    "POST /w/*" req
    (let [page-name (first (:path-params req))
          content (get (:form-params req) "content")]
      (save-page page-name content))))
```

Before:

```sh
$ clj-kondo --lint src/wiki/core.clj
src/wiki/core.clj:40:5: error: Function arguments should be wrapped in vector.
src/wiki/core.clj:40:11: error: Unresolved symbol: page-name
src/wiki/core.clj:41:11: error: Unresolved symbol: content
linting took 21ms, errors: 3, warnings: 0
```

After:

```sh
$ clj-kondo --lint src/wiki/core.clj
src/wiki/core.clj::: error: unsupported binding form bindings
src/wiki/core.clj:40:42: error: Unresolved symbol: req
linting took 104ms, errors: 2, warnings: 0
```

I'd love to fix this myself, so I'd appreciate any pointers!